### PR TITLE
typos

### DIFF
--- a/Game/Doc/Lemmas.lean
+++ b/Game/Doc/Lemmas.lean
@@ -107,7 +107,7 @@ LemmaDoc not_forall as "not_forall" in "Logic"
 
 LemmaDoc not_exists as "not_exists" in "Logic"
 "
-`not_exists {α : Sort _} {P : α → Prop} : (¬∃ x, P x) ↔ ∀ (x : α), ¬P x.
+`not_exists {α : Sort _} {P : α → Prop} : (¬∃ x, P x) ↔ ∀ (x : α), ¬P x`
 
 ## Eigenschaften
 

--- a/Game/Levels/Sum/L04_SumOdd.lean
+++ b/Game/Levels/Sum/L04_SumOdd.lean
@@ -23,7 +23,7 @@ open Fin
 open BigOperators
 
 Statement
-    "$\\sum_{i = 0}^n (2n + 1) = n ^ 2$."
+    "$\\sum_{i = 0}^n (2i + 1) = n ^ 2$."
     (n : ℕ) : (∑ i : Fin n, (2 * (i : ℕ) + 1)) = n ^ 2 := by
   Hint "**Robo**: Das funktioniert genau gleich wie zuvor, viel Glück."
   induction n


### PR DESCRIPTION
* add missing back-tick for `not_exists` definition to fix rendering issue
* fix variable name in sum description to match goal

Also, I think you might not be quite consistent with the upper bounds for sums in various descriptions. Perhaps that's to keep it simpler as `0 to n` instead of `0 to n-1` when not relevant. It was only slightly confusing, as someone who's just learning Lean.

I guess this is still work in progress but I thought it was quite good already (I've done all but the last 4 levels in the SetTheory world so far).