### PR TITLE
Fix LaTeX not escaping properly in L12_Insert.lean

### DIFF
--- a/Game/Levels/SetTheory/L12_Insert.lean
+++ b/Game/Levels/SetTheory/L12_Insert.lean
@@ -26,7 +26,7 @@ Die folgende Aufgabe ist entsprechend mit `rfl` lösbar.
 
 open Set
 
-/-- Die Menge $\\{4, 9\\}$ ist per Definition $\\{4}\\cup\\{9\\}$. -/
+/-- Die Menge `{4, 9}` ist per Definition `{4} ∪ {9}`. -/
 Statement :
     ({4, 9} : Set ℕ) = Set.insert 4 {9} := by
   rfl


### PR DESCRIPTION
Same problem in `Game/Levels/Sum/L01_Simp.lean`.