### PR TITLE
Replaces "\\iff" as a string literal with the unicode literal "↔" in Implis L09

### DIFF
--- a/.i18n/de/Game.po
+++ b/.i18n/de/Game.po
@@ -4450,7 +4450,7 @@ msgstr ""
 #. §1: `trans`
 #. §2: $B \\iff A \\iff D \\iff C$
 #. §3: `trans A`
-#. §4: `B \\iff A`
+#. §4: `B ↔ A`
 #. §5: `trans D`
 #: Game.Levels.Implis.L09_Trans
 msgid ""

--- a/.i18n/en/Game.po
+++ b/.i18n/en/Game.po
@@ -4335,7 +4335,7 @@ msgstr ""
 #. §1: `trans`
 #. §2: $B \\iff A \\iff D \\iff C$
 #. §3: `trans A`
-#. §4: `B \\iff A`
+#. §4: `B ↔ A`
 #. §5: `trans D`
 #: Game.Levels.Implis.L09_Trans
 msgid ""

--- a/.i18n/template/Game.pot
+++ b/.i18n/template/Game.pot
@@ -5402,7 +5402,7 @@ msgstr ""
 #. §1: `trans`
 #. §2: $B \\iff A \\iff D \\iff C$
 #. §3: `trans A`
-#. §4: `B \\iff A`
+#. §4: `B ↔ A`
 #. §5: `trans D`
 #: Game.Levels.Implis.L09_Trans
 msgid "Intro Implis L09: Instead of §0 use §1 here.\n"

--- a/Game/Levels/Implis/L09_Trans.lean
+++ b/Game/Levels/Implis/L09_Trans.lean
@@ -10,12 +10,12 @@ Introduction
 "
 **Du**: Irgendwie fühlen sich diese `rw` an, als würde man von hinten durch den Bauch argumentieren.  Geht das nicht auch irgendwie geradeaus, oder denken alle hier um die Ecke?
 
-**Robo**:  Vielleicht würde dir `trans` besser gefallen.  Damit könntest du deine Kette von Äquivalenzen  $B \\iff A \\iff D \\iff C$ Schritt für Schritt abarbeiten: als erstes führst Du mit `trans A` den Zwischenschritt `B \\iff A` ein, dann mit `trans D` den nächsten Zwischenschritt.
+**Robo**:  Vielleicht würde dir `trans` besser gefallen.  Damit könntest du deine Kette von Äquivalenzen  $B \\iff A \\iff D \\iff C$ Schritt für Schritt abarbeiten: als erstes führst Du mit `trans A` den Zwischenschritt `B ↔ A` ein, dann mit `trans D` den nächsten Zwischenschritt.
 "
 -/
 Introduction "Intro Implis L09: Instead of `rw` use `trans` here.
 With it you can solve $B \\iff A \\iff D \\iff C$ step-by-step by using
-`trans A` to introduce the intermediate step `B \\iff A` and then
+`trans A` to introduce the intermediate step `B ↔ A` and then
 perfrom The next step with `trans D`"
 
 Statement (A B C D : Prop) (h₁ : C ↔ D) (h₂ : A ↔ B) (h₃ : A ↔ D) : B ↔ C := by


### PR DESCRIPTION
Because this was being used in a string literal context (`` `…` ``) rather than a KaTeX context (`$…$`), it was being displayed verbatim as "\\iff"