### PR TITLE
Change `obtain \<t> := h` to use assumption h

### DIFF
--- a/.i18n/de/Game.po
+++ b/.i18n/de/Game.po
@@ -1003,7 +1003,7 @@ msgstr ""
 #. §15: `ha : a ∈ A`
 #. §16: `use a`
 #. §17: `h : Nonempty T`
-#. §18: `obtain ⟨t⟩ := t`
+#. §18: `obtain ⟨t⟩ := h`
 #. §19: `t`
 #. §20: `t : T`
 #. §21: `h : Nonempty A`

--- a/.i18n/en/Game.po
+++ b/.i18n/en/Game.po
@@ -967,7 +967,7 @@ msgstr ""
 #. §15: `ha : a ∈ A`
 #. §16: `use a`
 #. §17: `h : Nonempty T`
-#. §18: `obtain ⟨t⟩ := t`
+#. §18: `obtain ⟨t⟩ := h`
 #. §19: `t`
 #. §20: `t : T`
 #. §21: `h : Nonempty A`

--- a/.i18n/template/Game.pot
+++ b/.i18n/template/Game.pot
@@ -417,7 +417,7 @@ msgstr ""
 #. §15: `ha : a ∈ A`
 #. §16: `use a`
 #. §17: `h : Nonempty T`
-#. §18: `obtain ⟨t⟩ := t`
+#. §18: `obtain ⟨t⟩ := h`
 #. §19: `t`
 #. §20: `t : T`
 #. §21: `h : Nonempty A`

--- a/Game/Doc/Definition.lean
+++ b/Game/Doc/Definition.lean
@@ -262,7 +262,7 @@ As goal:
 given `t`, `t : T`, use `use t`
 given `a`, `a : T` such that `a ∈ A`, `ha : a ∈ A`, use `use a`
 As assumption:
-given `h : Nonempty T`, use `obtain ⟨t⟩ := t` to obtain `t`, `t : T`
+given `h : Nonempty T`, use `obtain ⟨t⟩ := h` to obtain `t`, `t : T`
 given `h : Nonempty A`, use `obtain ⟨a, ha⟩ := h` to obtain `a`, `a : T`, `a ∈ A`, `ha : a ∈ A`
 -/
 DefinitionDoc Nonempty as "Nonempty"


### PR DESCRIPTION
The original example usage of `obtain` with an assumption of a `Nonempty` type `T` is incorrect. I tried to correct the error by simply searching the codebase and matching on the occurrence of the pattern `obtain \<t> := t`.